### PR TITLE
Minor error if newer version of Pytorch is used 

### DIFF
--- a/Pytorch_MNIST.ipynb
+++ b/Pytorch_MNIST.ipynb
@@ -205,7 +205,7 @@
         "    \n",
         "    if (i+1) % 100 == 0:\n",
         "      print('Epoch [%d/%d], Step [%d/%d], Loss: %.4f'\n",
-        "                 %(epoch+1, num_epochs, i+1, len(train_data)//batch_size, loss.data[0]))"
+        "                 %(epoch+1, num_epochs, i+1, len(train_data)//batch_size, loss.data))"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
loss_val.data[0] does not work for PyTorch>=0.5. Check https://github.com/NVIDIA/flownet2-pytorch/issues/113.